### PR TITLE
Add MAUI timer project

### DIFF
--- a/IntervalTimerApp/App.xaml
+++ b/IntervalTimerApp/App.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             x:Class="IntervalTimerApp.App">
+  <Application.Resources>
+  </Application.Resources>
+</Application>

--- a/IntervalTimerApp/App.xaml.cs
+++ b/IntervalTimerApp/App.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace IntervalTimerApp
+{
+    public partial class App : Application
+    {
+        public App()
+        {
+            InitializeComponent();
+            MainPage = new NavigationPage(new Views.MainPage());
+        }
+    }
+}

--- a/IntervalTimerApp/IntervalTimerApp.csproj
+++ b/IntervalTimerApp/IntervalTimerApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>IntervalTimerApp</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <MauiFont Include="Resources/Fonts/OpenSans-Regular.ttf" Alias="OpenSansRegular" />
+    <MauiFont Include="Resources/Fonts/OpenSans-Semibold.ttf" Alias="OpenSansSemibold" />
+    <MauiXaml Include="**/*.xaml" />
+  </ItemGroup>
+</Project>

--- a/IntervalTimerApp/MauiProgram.cs
+++ b/IntervalTimerApp/MauiProgram.cs
@@ -1,0 +1,23 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
+
+namespace IntervalTimerApp
+{
+    public static class MauiProgram
+    {
+        public static MauiApp CreateMauiApp()
+        {
+            var builder = MauiApp.CreateBuilder();
+            builder
+                .UseMauiApp<App>()
+                .ConfigureFonts(fonts =>
+                {
+                    fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                    fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+                });
+
+            return builder.Build();
+        }
+    }
+}

--- a/IntervalTimerApp/Models/TimerInterval.cs
+++ b/IntervalTimerApp/Models/TimerInterval.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace IntervalTimerApp.Models
+{
+    public class TimerInterval
+    {
+        public int Seconds { get; set; }
+    }
+}

--- a/IntervalTimerApp/Models/TimerTemplate.cs
+++ b/IntervalTimerApp/Models/TimerTemplate.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace IntervalTimerApp.Models
+{
+    public class TimerTemplate
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<TimerInterval> Intervals { get; set; } = new();
+        public int Repetitions { get; set; }
+    }
+}

--- a/IntervalTimerApp/Platforms/Android/MainActivity.cs
+++ b/IntervalTimerApp/Platforms/Android/MainActivity.cs
@@ -1,0 +1,11 @@
+using Android.App;
+using Android.Content.PM;
+using Microsoft.Maui;
+
+namespace IntervalTimerApp
+{
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    public class MainActivity : MauiAppCompatActivity
+    {
+    }
+}

--- a/IntervalTimerApp/Platforms/Android/MainApplication.cs
+++ b/IntervalTimerApp/Platforms/Android/MainApplication.cs
@@ -1,0 +1,17 @@
+using Android.App;
+using Android.Runtime;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace IntervalTimerApp
+{
+    [Application]
+    public class MainApplication : MauiApplication
+    {
+        public MainApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+        {
+        }
+
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    }
+}

--- a/IntervalTimerApp/Platforms/iOS/AppDelegate.cs
+++ b/IntervalTimerApp/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,12 @@
+using Foundation;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace IntervalTimerApp
+{
+    [Register("AppDelegate")]
+    public class AppDelegate : MauiUIApplicationDelegate
+    {
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    }
+}

--- a/IntervalTimerApp/Platforms/iOS/Main.cs
+++ b/IntervalTimerApp/Platforms/iOS/Main.cs
@@ -1,0 +1,12 @@
+using UIKit;
+
+namespace IntervalTimerApp
+{
+    public class Application
+    {
+        static void Main(string[] args)
+        {
+            UIApplication.Main(args, null, typeof(AppDelegate));
+        }
+    }
+}

--- a/IntervalTimerApp/Program.cs
+++ b/IntervalTimerApp/Program.cs
@@ -1,0 +1,16 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace IntervalTimerApp
+{
+    internal class Program : MauiApplication
+    {
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+        static void Main(string[] args)
+        {
+            var app = new Program();
+            app.Run(args);
+        }
+    }
+}

--- a/IntervalTimerApp/Resources/Styles/Styles.xaml
+++ b/IntervalTimerApp/Resources/Styles/Styles.xaml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    x:Class="IntervalTimerApp.Styles">
+</ResourceDictionary>

--- a/IntervalTimerApp/Services/TemplateService.cs
+++ b/IntervalTimerApp/Services/TemplateService.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using IntervalTimerApp.Models;
+using Microsoft.Maui.Storage;
+
+namespace IntervalTimerApp.Services
+{
+    public class TemplateService
+    {
+        private readonly string _filePath;
+
+        public TemplateService()
+        {
+            _filePath = Path.Combine(FileSystem.AppDataDirectory, "templates.json");
+        }
+
+        public async Task<List<TimerTemplate>> LoadTemplatesAsync()
+        {
+            if (!File.Exists(_filePath))
+            {
+                return new List<TimerTemplate>();
+            }
+
+            using var stream = File.OpenRead(_filePath);
+            return await JsonSerializer.DeserializeAsync<List<TimerTemplate>>(stream) ?? new List<TimerTemplate>();
+        }
+
+        public async Task SaveTemplatesAsync(List<TimerTemplate> templates)
+        {
+            using var stream = File.Create(_filePath);
+            await JsonSerializer.SerializeAsync(stream, templates, new JsonSerializerOptions { WriteIndented = true });
+        }
+    }
+}

--- a/IntervalTimerApp/Views/EditTemplatePage.xaml
+++ b/IntervalTimerApp/Views/EditTemplatePage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             x:Class="IntervalTimerApp.Views.EditTemplatePage"
+             Title="Template">
+    <StackLayout Spacing="10" Padding="20">
+        <Entry x:Name="NameEntry" Placeholder="Name" />
+        <Entry x:Name="RepetitionEntry" Placeholder="Repetitions" Keyboard="Numeric" />
+        <Label Text="Intervals (seconds, comma separated)" />
+        <Entry x:Name="IntervalsEntry" Placeholder="e.g. 1500,300" />
+        <Button Text="Save" Clicked="OnSaveClicked" />
+    </StackLayout>
+</ContentPage>

--- a/IntervalTimerApp/Views/EditTemplatePage.xaml.cs
+++ b/IntervalTimerApp/Views/EditTemplatePage.xaml.cs
@@ -1,0 +1,34 @@
+using Microsoft.Maui.Controls;
+using IntervalTimerApp.Models;
+using IntervalTimerApp.Services;
+using System;
+using System.Linq;
+
+namespace IntervalTimerApp.Views
+{
+    public partial class EditTemplatePage : ContentPage
+    {
+        private readonly TemplateService _service;
+
+        public EditTemplatePage(TemplateService service)
+        {
+            InitializeComponent();
+            _service = service;
+        }
+
+        private async void OnSaveClicked(object sender, EventArgs e)
+        {
+            var template = new TimerTemplate
+            {
+                Name = NameEntry.Text ?? string.Empty,
+                Repetitions = int.TryParse(RepetitionEntry.Text, out var rep) ? rep : 1,
+                Intervals = IntervalsEntry.Text?.Split(',').Select(s => new TimerInterval { Seconds = int.Parse(s.Trim()) }).ToList() ?? new()
+            };
+
+            var templates = await _service.LoadTemplatesAsync();
+            templates.Add(template);
+            await _service.SaveTemplatesAsync(templates);
+            await Navigation.PopAsync();
+        }
+    }
+}

--- a/IntervalTimerApp/Views/MainPage.xaml
+++ b/IntervalTimerApp/Views/MainPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             x:Class="IntervalTimerApp.Views.MainPage"
+             Title="Templates">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Add" Clicked="OnAddClicked" />
+    </ContentPage.ToolbarItems>
+    <CollectionView ItemsSource="{Binding Templates}" SelectionMode="Single" SelectionChanged="OnTemplateSelected">
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <TextCell Text="{Binding Name}" Detail="{Binding Repetitions}"/>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/IntervalTimerApp/Views/MainPage.xaml.cs
+++ b/IntervalTimerApp/Views/MainPage.xaml.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using IntervalTimerApp.Models;
+using IntervalTimerApp.Services;
+
+namespace IntervalTimerApp.Views
+{
+    public partial class MainPage : ContentPage
+    {
+        private readonly TemplateService _service = new();
+
+        public ObservableCollection<TimerTemplate> Templates { get; } = new();
+
+        public MainPage()
+        {
+            InitializeComponent();
+            BindingContext = this;
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            Templates.Clear();
+            var templates = await _service.LoadTemplatesAsync();
+            foreach (var t in templates)
+                Templates.Add(t);
+        }
+
+        private async void OnAddClicked(object sender, EventArgs e)
+        {
+            await Navigation.PushAsync(new EditTemplatePage(_service));
+        }
+
+        private async void OnTemplateSelected(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.CurrentSelection.FirstOrDefault() is TimerTemplate template)
+            {
+                await Navigation.PushAsync(new TimerPage(template));
+            }
+        }
+    }
+}

--- a/IntervalTimerApp/Views/TimerPage.xaml
+++ b/IntervalTimerApp/Views/TimerPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             x:Class="IntervalTimerApp.Views.TimerPage"
+             Title="Timer">
+    <StackLayout Spacing="20" Padding="20">
+        <Label x:Name="TimerLabel" FontSize="48" HorizontalOptions="Center" />
+        <Button Text="Start" Clicked="OnStartClicked" />
+    </StackLayout>
+</ContentPage>

--- a/IntervalTimerApp/Views/TimerPage.xaml.cs
+++ b/IntervalTimerApp/Views/TimerPage.xaml.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using System.Threading;
+using IntervalTimerApp.Models;
+using Microsoft.Maui.Essentials;
+
+namespace IntervalTimerApp.Views
+{
+    public partial class TimerPage : ContentPage
+    {
+        private readonly TimerTemplate _template;
+        private int _currentIntervalIndex;
+        private int _currentRepetition;
+        private CancellationTokenSource? _cts;
+
+        public TimerPage(TimerTemplate template)
+        {
+            InitializeComponent();
+            _template = template;
+        }
+
+        private async void OnStartClicked(object sender, EventArgs e)
+        {
+            _cts?.Cancel();
+            _cts = new CancellationTokenSource();
+
+            _currentIntervalIndex = 0;
+            _currentRepetition = 0;
+            await RunTimer(_cts.Token);
+        }
+
+        private async Task RunTimer(CancellationToken token)
+        {
+            while (_currentRepetition < _template.Repetitions)
+            {
+                var interval = _template.Intervals[_currentIntervalIndex];
+                for (int i = interval.Seconds; i >= 0; i--)
+                {
+                    TimerLabel.Text = TimeSpan.FromSeconds(i).ToString();
+                    if (i <= 3 && i > 0)
+                    {
+                        // Play beep here (placeholder)
+                        try { Vibration.Vibrate(TimeSpan.FromMilliseconds(200)); } catch { }
+                    }
+                    await Task.Delay(1000, token);
+                    if (token.IsCancellationRequested) return;
+                }
+                _currentIntervalIndex++;
+                if (_currentIntervalIndex >= _template.Intervals.Count)
+                {
+                    _currentIntervalIndex = 0;
+                    _currentRepetition++;
+                }
+            }
+            await DisplayAlert("Done", "Timer complete", "OK");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # IntervalTimer
-Interval Timer by Codex
+
+This repository contains a basic .NET MAUI application for Android and iOS that implements a configurable interval timer. Users can create templates consisting of multiple time intervals and a global repetition count. Templates are stored locally on the device.
+
+## Structure
+- **IntervalTimerApp** – MAUI project containing the code
+  - `Models` – timer data classes
+  - `Services` – simple JSON storage service
+  - `Views` – pages used in the application
+  - `Platforms` – platform specific stubs for Android and iOS
+
+## Usage
+This project was created manually without running `dotnet new maui`. If you have a .NET MAUI environment, open the solution and deploy to Android or iOS.


### PR DESCRIPTION
## Summary
- add IntervalTimerApp project with basic timer functionality
- store timer templates locally in JSON
- include stub platform code for Android and iOS
- update README with project description

## Testing
- `dotnet build IntervalTimerApp/IntervalTimerApp.csproj -t:Restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684443ec70808328953596351d926603